### PR TITLE
Update reference to global to be globalThis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Stringifier
-var toString = global.JSON && typeof JSON.stringify === 'function' ? JSON.stringify : String;
+var toString = globalThis.JSON && typeof JSON.stringify === 'function' ? JSON.stringify : String;
 
 /**
  * Format the given `str`.


### PR DESCRIPTION
This specific reference to `global` is Node-specific. According to the [Node globals documentation](https://nodejs.org/api/globals.html#globals_global), this should be updated to `globalThis`. After this, the package becomes browser-friendly which fixes an issue with bundling certain integrations manually.

Resolves https://github.com/segmentio/analytics.js-integrations/issues/807.